### PR TITLE
Force dark mode on site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,6 +72,11 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     image: 'https://res.cloudinary.com/dfnq1g0fu/image/upload/v1750596320/social-card-500_wlfoz1.gif',
+    colorMode: {
+      defaultMode: 'dark',
+      disableSwitch: true,
+      respectPrefersColorScheme: false,
+    },
     navbar: {
       title: 'Active Learning',
       logo: {


### PR DESCRIPTION
## Summary
- set color mode defaults in docusaurus config to dark
- disable switch so the toggle disappears

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685811984d188325bc76a44adec35657