### PR TITLE
Add web-based physics sim doc and example component

### DIFF
--- a/docs/stem/web-based-physics-simulations.mdx
+++ b/docs/stem/web-based-physics-simulations.mdx
@@ -1,0 +1,26 @@
+---
+sidebar_position: 12
+---
+
+# Web-Based Physics Simulations
+
+Interactive simulations let students explore physical principles in a dynamic way without specialized lab equipment. Many instructors use the open-source [PhET](https://phet.colorado.edu/) collection from the University of Colorado Boulder. Research shows that PhET activities improve conceptual understanding and student engagement (**Perkins et al., 2006; Adams et al., 2008**).
+
+## Why Simulations Are Valuable
+
+- **Safe experimentation:** Students can manipulate variables like mass or friction without risk.
+- **Immediate feedback:** Visual results help them connect equations with motion.
+- **Accessibility:** Simulations run in a browser, so learners can explore at home or in class.
+
+## Example: Projectile Motion Simulator
+
+The following custom React component allows students to adjust launch angle and speed to see how a projectile travels under gravity. By predicting the trajectory and then testing it, learners confront their preconceptions about parabolic motion and the relationship between horizontal and vertical components of velocity.
+
+<ProjectileMotionSim />
+
+Students can experiment with different angles and speeds to observe how both affect range and maximum height. Encouraging them to sketch the expected path before adjusting the sliders mirrors the predict–observe–explain cycle common in active learning. Studies of simulation use in physics courses report gains in problem‑solving ability when students manipulate variables themselves (**Finkelstein et al., 2005**).
+
+## Additional Resources
+
+- Browse the extensive [PhET simulation library](https://phet.colorado.edu/en/simulations/filter?subjects=physics).
+- For tips on integrating simulations with other active learning methods, see the [Interactive Demonstrations](./interactive-demonstrations) article.

--- a/src/components/physics-simulations/ProjectileMotionSim.tsx
+++ b/src/components/physics-simulations/ProjectileMotionSim.tsx
@@ -1,0 +1,82 @@
+import React, {useRef, useEffect, useState} from 'react';
+
+export default function ProjectileMotionSim() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [angle, setAngle] = useState(45);
+  const [velocity, setVelocity] = useState(20);
+  const width = 400;
+  const height = 300;
+  const g = 9.8; // acceleration due to gravity
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, width, height);
+
+    // ground line
+    ctx.beginPath();
+    ctx.moveTo(0, height - 1);
+    ctx.lineTo(width, height - 1);
+    ctx.strokeStyle = '#000';
+    ctx.stroke();
+
+    ctx.strokeStyle = '#2980b9';
+    ctx.lineWidth = 2;
+
+    const angleRad = (angle * Math.PI) / 180;
+    const vX = velocity * Math.cos(angleRad);
+    const vY = velocity * Math.sin(angleRad);
+    const tMax = (2 * vY) / g;
+    const step = tMax / 50;
+
+    ctx.beginPath();
+    ctx.moveTo(0, height - 1);
+    for (let t = 0; t <= tMax; t += step) {
+      const x = vX * t;
+      const y = vY * t - 0.5 * g * t * t;
+      const canvasX = x * 10; // scale for visibility
+      const canvasY = height - y * 10;
+      if (canvasX > width) break;
+      ctx.lineTo(canvasX, canvasY);
+    }
+    ctx.stroke();
+  }, [angle, velocity]);
+
+  return (
+    <div>
+      <label>
+        Angle:
+        <input
+          type="range"
+          min="10"
+          max="80"
+          value={angle}
+          onChange={(e) => setAngle(Number(e.target.value))}
+          style={{marginLeft: '0.5rem'}}
+        />
+        {angle}°
+      </label>
+      <br />
+      <label>
+        Velocity:
+        <input
+          type="range"
+          min="5"
+          max="30"
+          value={velocity}
+          onChange={(e) => setVelocity(Number(e.target.value))}
+          style={{marginLeft: '0.5rem'}}
+        />
+        {velocity} m/s
+      </label>
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        style={{border: '1px solid #ccc', marginTop: '1rem', width: width, height: height}}
+      />
+    </div>
+  );
+}

--- a/src/components/physics-simulations/index.ts
+++ b/src/components/physics-simulations/index.ts
@@ -1,0 +1,1 @@
+export { default as ProjectileMotionSim } from './ProjectileMotionSim';

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import MDXComponents from '@theme-original/MDXComponents';
-import { Video, LoopingVideo, FloatingVideo, InlineVideo, InlineFloatingVideo, EmilyH1, SEO } from '@site/src/components/mk';
+import {
+  Video,
+  LoopingVideo,
+  FloatingVideo,
+  InlineVideo,
+  InlineFloatingVideo,
+  EmilyH1,
+  SEO,
+} from '@site/src/components/mk';
+import { ProjectileMotionSim } from '@site/src/components/physics-simulations';
 
 export default {
   ...MDXComponents,
@@ -11,4 +20,5 @@ export default {
   InlineFloatingVideo,
   EmilyH1,
   SEO,
+  ProjectileMotionSim,
 };


### PR DESCRIPTION
## Summary
- document value of web-based physics simulations with PhET overview
- add ProjectileMotionSim React component as an example sim
- expose the component globally for MDX usage

## Testing
- `pnpm run typecheck` *(fails: Cannot find module '@docusaurus/tsconfig')*

------
https://chatgpt.com/codex/tasks/task_e_6858120be0988325994f4526e9348a05