### PR TITLE
Add digital simulation docs and components

### DIFF
--- a/docs/digital-simulations/_category_.json
+++ b/docs/digital-simulations/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Digital Simulations",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Interactive digital simulations for STEM and humanities courses."
+  }
+}

--- a/docs/digital-simulations/chemical-equilibrium.mdx
+++ b/docs/digital-simulations/chemical-equilibrium.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 3
+---
+
+# Chemical Equilibrium Simulator (STEM)
+
+Manipulate reactant concentration to observe how equilibrium shifts.
+
+<ReactionRateSim />

--- a/docs/digital-simulations/circuit-builder.mdx
+++ b/docs/digital-simulations/circuit-builder.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# Circuit Builder (STEM)
+
+Students can adjust resistance and voltage to see how current changes according to Ohm's law.
+
+<CircuitBuilderSim />

--- a/docs/digital-simulations/historical-map-viewer.mdx
+++ b/docs/digital-simulations/historical-map-viewer.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+---
+
+# Historical Map Viewer (Humanities)
+
+Move the year slider to see how the political map changes over time.
+
+<MapExplorerSim />

--- a/docs/digital-simulations/index.md
+++ b/docs/digital-simulations/index.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: "Introduction"
+---
+
+# Digital Simulations
+
+Digital simulations provide immersive, interactive environments for students to test ideas and visualize concepts. Whether exploring scientific phenomena or historical artifacts, these tools bring abstract ideas to life.
+
+## About This Section
+
+The pages in this section highlight small in-browser simulations designed for both STEM and humanities classrooms. Each example includes a simple interactive component students can manipulate.

--- a/docs/digital-simulations/virtual-art-gallery.mdx
+++ b/docs/digital-simulations/virtual-art-gallery.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 4
+---
+
+# Virtual Art Gallery (Humanities)
+
+Explore artworks from different eras by moving the slider.
+
+<VirtualGallerySim />

--- a/src/components/digital-simulations/humanities/MapExplorerSim.tsx
+++ b/src/components/digital-simulations/humanities/MapExplorerSim.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+export default function MapExplorerSim() {
+  const [year, setYear] = useState(1900);
+
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <label>
+        Year:
+        <input
+          type="range"
+          min="1800"
+          max="2000"
+          step="10"
+          value={year}
+          onChange={(e) => setYear(Number(e.target.value))}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        {year}
+      </label>
+      <p>Map changes for {year}</p>
+    </div>
+  );
+}

--- a/src/components/digital-simulations/humanities/VirtualGallerySim.tsx
+++ b/src/components/digital-simulations/humanities/VirtualGallerySim.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+const artworks = [
+  { year: '1500s', caption: 'Renaissance portrait' },
+  { year: '1800s', caption: 'Impressionist landscape' },
+  { year: '2000s', caption: 'Digital abstraction' },
+];
+
+export default function VirtualGallerySim() {
+  const [index, setIndex] = useState(0);
+  const artwork = artworks[index];
+
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <label>
+        Era:
+        <input
+          type="range"
+          min="0"
+          max={artworks.length - 1}
+          value={index}
+          onChange={(e) => setIndex(Number(e.target.value))}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        {artwork.year}
+      </label>
+      <p>{artwork.caption}</p>
+    </div>
+  );
+}

--- a/src/components/digital-simulations/humanities/index.ts
+++ b/src/components/digital-simulations/humanities/index.ts
@@ -1,0 +1,2 @@
+export { default as VirtualGallerySim } from './VirtualGallerySim';
+export { default as MapExplorerSim } from './MapExplorerSim';

--- a/src/components/digital-simulations/index.ts
+++ b/src/components/digital-simulations/index.ts
@@ -1,0 +1,2 @@
+export * from './stem';
+export * from './humanities';

--- a/src/components/digital-simulations/stem/CircuitBuilderSim.tsx
+++ b/src/components/digital-simulations/stem/CircuitBuilderSim.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+export default function CircuitBuilderSim() {
+  const [voltage, setVoltage] = useState(5);
+  const [resistance, setResistance] = useState(10);
+  const current = voltage / resistance;
+
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <label>
+        Voltage (V):
+        <input
+          type="range"
+          min="1"
+          max="10"
+          value={voltage}
+          onChange={(e) => setVoltage(Number(e.target.value))}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        {voltage}
+      </label>
+      <br />
+      <label>
+        Resistance (Ω):
+        <input
+          type="range"
+          min="1"
+          max="20"
+          value={resistance}
+          onChange={(e) => setResistance(Number(e.target.value))}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        {resistance}
+      </label>
+      <p>Current: {current.toFixed(2)} A</p>
+    </div>
+  );
+}

--- a/src/components/digital-simulations/stem/ReactionRateSim.tsx
+++ b/src/components/digital-simulations/stem/ReactionRateSim.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+export default function ReactionRateSim() {
+  const [concentration, setConcentration] = useState(1);
+  // simple model: rate proportional to concentration squared
+  const rate = concentration * concentration;
+
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <label>
+        Concentration (M):
+        <input
+          type="range"
+          min="0"
+          max="5"
+          step="0.1"
+          value={concentration}
+          onChange={(e) => setConcentration(Number(e.target.value))}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        {concentration.toFixed(1)}
+      </label>
+      <p>Relative Rate: {rate.toFixed(2)}</p>
+    </div>
+  );
+}

--- a/src/components/digital-simulations/stem/index.ts
+++ b/src/components/digital-simulations/stem/index.ts
@@ -1,0 +1,2 @@
+export { default as CircuitBuilderSim } from './CircuitBuilderSim';
+export { default as ReactionRateSim } from './ReactionRateSim';

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -10,6 +10,12 @@ import {
   SEO,
 } from '@site/src/components/mk';
 import { ProjectileMotionSim } from '@site/src/components/physics-simulations';
+import {
+  CircuitBuilderSim,
+  ReactionRateSim,
+  VirtualGallerySim,
+  MapExplorerSim,
+} from '@site/src/components/digital-simulations';
 
 export default {
   ...MDXComponents,
@@ -21,4 +27,8 @@ export default {
   EmilyH1,
   SEO,
   ProjectileMotionSim,
+  CircuitBuilderSim,
+  ReactionRateSim,
+  VirtualGallerySim,
+  MapExplorerSim,
 };


### PR DESCRIPTION
## Summary
- add a new docs section `digital-simulations`
- include two STEM and two humanities simulation examples
- implement new interactive React components
- expose the components through the MDX theme

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6858176228bc832594b705b3763bde42