### PR TITLE
Fix mobile navbar items

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -78,18 +78,15 @@ const config: Config = {
       respectPrefersColorScheme: false,
     },
     navbar: {
-      title: 'Active Learning',
+      // Display "Home" as the brand link text
+      title: 'Home',
       logo: {
-        alt: 'My Site Logo',
+        alt: 'Active Learning Logo',
         src: 'img/rainbow-bot.jpg',
       },
       items: [
-        {
-          type: 'docSidebar',
-          sidebarId: 'tutorialSidebar',
-          position: 'left',
-          label: 'Docs',
-        },
+        // Explicit nav items so they appear in the mobile menu
+        {to: '/docs/intro', label: 'Docs', position: 'left'},
         {to: '/blog', label: 'Blog', position: 'left'},
         {
           href: 'https://github.com/facebook/docusaurus',


### PR DESCRIPTION
## Summary
- change navbar title to `Home`
- declare explicit Docs and Blog links for consistent mobile menu

## Testing
- `pnpm install` *(fails: Could not connect to registry)*
- `pnpm build` *(not run due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_6859414d1ae88325ba55cace3b32a50f